### PR TITLE
Relax LSTM demo

### DIFF
--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -50,6 +50,11 @@ def softmax_cross_entropy(lhs: Expr, rhs: Expr) -> Expr:
 def flatten(data: Expr) -> Expr:
     return _make.flatten(data)
 
+def sigmoid(data: Expr) -> Expr:
+    return _make.sigmoid(data)
+
+def tanh(data: Expr) -> Expr:
+    return _make.tanh(data)
 
 def max_pool2d(data: Expr, kernel_size, stride=None, padding=(0, 0), dilation=(1, 1)) -> Expr:
     if stride is None:

--- a/src/relax/op/training/training_nn.cc
+++ b/src/relax/op/training/training_nn.cc
@@ -27,6 +27,8 @@ namespace relax {
 RELAX_REGISTER_UNARY_OP("nn.relu");
 RELAX_REGISTER_UNARY_OP("nn.gradrelu_");
 RELAX_REGISTER_UNARY_OP("nn.softmax");
+RELAX_REGISTER_UNARY_OP("nn.sigmoid");
+RELAX_REGISTER_UNARY_OP("nn.tanh");
 
 RELAX_REGISTER_BINARY_OP_BASE("nn.dense", InferShapeDense, InferTypeDense);
 RELAX_REGISTER_BINARY_OP_BASE("nn.cross_entropy", InferShapeCrossEntropy, InferTypeCrossEntropy);

--- a/tests/python/relax/training/_gradient.py
+++ b/tests/python/relax/training/_gradient.py
@@ -14,7 +14,9 @@ from tvm.relax.op import (
 
 from tvm.relax.op.nn import (
 	gradrelu_,
-	softmax
+	softmax,
+	sigmoid,
+	tanh
 )
 
 @register_gradient("relax.add")
@@ -80,3 +82,13 @@ def softmax_cross_entropy_grad(orig, grad):
 	y_hat = softmax(orig.args[0])
 	return [multiply(grad, sub(y_hat, orig.args[1])), multiply(grad, negative(log(y_hat)))]
 	# return [sub(y_hat, orig.args[1]), negative(log(y_hat))]
+
+@register_gradient("relax.nn.sigmoid")
+def sigmoid_grad(orig, grad):
+	out = sigmoid(orig.args[0])
+	return [multiply(grad, multiply(out, sub(ones_like(out), out)))]
+
+@register_gradient("relax.nn.tanh")
+def tanh_grad(orig, grad):
+	out = tanh(orig.args[0])
+	return [multiply(grad, sub(ones_like(out), multiply(out, out)))]

--- a/tests/python/relax/training/test_high_level_op.py
+++ b/tests/python/relax/training/test_high_level_op.py
@@ -37,8 +37,10 @@ from utils import LowerToTensorIRPass
 #   dense
 #   cross_entropy
 #   softmax_cross_entropy
+#   sigmoid
+#   tanh
 
-def gen_and_run(op, *input_data):
+def run_relax(op, *input_data):
     """
         generate module and run it to get output
         ---
@@ -69,38 +71,38 @@ def gen_and_run(op, *input_data):
 def test_transpose():
     data_numpy = np.random.randint(0, 16, (3, 4)).astype(np.float32)
     expected_output = np.transpose(data_numpy)
-    result = gen_and_run(relax.op.transpose, data_numpy)
+    result = run_relax(relax.op.transpose, data_numpy)
     np.testing.assert_array_equal(expected_output, result.numpy())
 
 def test_log():
     data_numpy = np.random.randint(1, 16, (16, 16)).astype(np.float32)
     expected_output = np.log(data_numpy)
-    result = gen_and_run(relax.op.log, data_numpy)
+    result = run_relax(relax.op.log, data_numpy)
     np.testing.assert_allclose(expected_output, result.numpy(), rtol=1e-6, atol=1e-6)
 
 def test_negative():
     data_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
     expected_output = np.negative(data_numpy)
-    result = gen_and_run(relax.op.negative, data_numpy)
+    result = run_relax(relax.op.negative, data_numpy)
     np.testing.assert_allclose(expected_output, result.numpy(), rtol=1e-6, atol=1e-6)
 
 def test_ones_like():
     data_numpy = np.zeros((16, 16)).astype(np.float32)
     expected_output = np.ones_like(data_numpy)
-    result = gen_and_run(relax.op.ones_like, data_numpy)
+    result = run_relax(relax.op.ones_like, data_numpy)
     np.testing.assert_array_equal(expected_output, result.numpy())
 
 def test_zeros_like():
     data_numpy = np.zeros((16, 16)).astype(np.float32)
     expected_output = np.zeros_like(data_numpy)
-    result = gen_and_run(relax.op.zeros_like, data_numpy)
+    result = run_relax(relax.op.zeros_like, data_numpy)
     np.testing.assert_array_equal(expected_output, result.numpy())
 
 def test_matmul():
     data1_numpy = np.random.randint(0, 16, (7, 8)).astype(np.float32)
     data2_numpy = np.random.randint(0, 16, (8, 10)).astype(np.float32)
     expected_output = np.matmul(data1_numpy, data2_numpy)
-    result = gen_and_run(relax.op.matmul, data1_numpy, data2_numpy)
+    result = run_relax(relax.op.matmul, data1_numpy, data2_numpy)
     np.testing.assert_array_equal(expected_output, result.numpy())
 
 def test_collapse_sum_like():
@@ -108,19 +110,19 @@ def test_collapse_sum_like():
     data2_numpy = np.zeros((10,)).astype(np.float32)
     expected_output = data1_numpy.reshape((10,))
     assert not np.array_equal(data1_numpy, expected_output)
-    result = gen_and_run(relax.op.collapse_sum_like, data1_numpy, data2_numpy)
+    result = run_relax(relax.op.collapse_sum_like, data1_numpy, data2_numpy)
     np.testing.assert_array_equal(expected_output, result.numpy())
 
 def test_relu():
     data_numpy = np.random.randint(-16, 16, (16, 16)).astype(np.float32)
     expected_output = np.maximum(data_numpy, 0)
-    result = gen_and_run(relax.op.nn.relu, data_numpy)
+    result = run_relax(relax.op.nn.relu, data_numpy)
     np.testing.assert_allclose(expected_output, result.numpy(), rtol=1e-6, atol=1e-6)
 
 def test_gradrelu_():
     data_numpy = np.random.randint(-16, 16, (16, 16)).astype(np.float32)
     expected_output = (data_numpy > 0).astype(np.float32)
-    result = gen_and_run(relax.op.nn.gradrelu_, data_numpy)
+    result = run_relax(relax.op.nn.gradrelu_, data_numpy)
     np.testing.assert_array_equal(expected_output, result.numpy())
 
 def softmax_numpy(x):
@@ -130,14 +132,14 @@ def softmax_numpy(x):
 def test_softmax():
     data_numpy = np.random.randint(-16, 16, (10,)).astype(np.float32)
     expected_output = softmax_numpy(data_numpy)
-    result = gen_and_run(relax.op.nn.softmax, data_numpy)
+    result = run_relax(relax.op.nn.softmax, data_numpy)
     np.testing.assert_allclose(expected_output, result.numpy(), rtol=1e-6, atol=1e-6)
 
 def test_dense():
     data1_numpy = np.random.randint(0, 16, (3, 4)).astype(np.float32)
     data2_numpy = np.random.randint(0, 16, (3, 4)).astype(np.float32)
     expected_output = np.matmul(data1_numpy, data2_numpy.T)
-    result = gen_and_run(relax.op.nn.dense, data1_numpy, data2_numpy)
+    result = run_relax(relax.op.nn.dense, data1_numpy, data2_numpy)
     np.testing.assert_allclose(expected_output, result.numpy(), rtol=1e-6, atol=1e-6)
 
 def cross_entropy_numpy(x, y):
@@ -147,20 +149,35 @@ def test_cross_entropy():
     data1_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
     data2_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
     expected_output = cross_entropy_numpy(data1_numpy, data2_numpy)
-    result = gen_and_run(relax.op.nn.cross_entropy, data1_numpy, data2_numpy)
+    result = run_relax(relax.op.nn.cross_entropy, data1_numpy, data2_numpy)
     np.testing.assert_allclose(expected_output, result.numpy(), rtol=1e-6, atol=1e-6)
 
 def test_softmax_cross_entropy():
     data1_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
     data2_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
     expected_output = cross_entropy_numpy(softmax_numpy(data1_numpy), data2_numpy)
-    result = gen_and_run(relax.op.nn.softmax_cross_entropy, data1_numpy, data2_numpy)
+    result = run_relax(relax.op.nn.softmax_cross_entropy, data1_numpy, data2_numpy)
     np.testing.assert_allclose(expected_output, result.numpy(), rtol=1e-6, atol=1e-6)
 
 def test_sum():
     data_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
     expected_output = np.sum(data_numpy)
-    result = gen_and_run(relax.op.sum, data_numpy)
+    result = run_relax(relax.op.sum, data_numpy)
+    np.testing.assert_allclose(expected_output, result.numpy(), rtol=1e-6, atol=1e-6)
+
+def sigmoid_numpy(z):
+    return 1/(1 + np.exp(-z))
+
+def test_sigmoid():
+    data_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
+    expected_output = sigmoid_numpy(data_numpy)
+    result = run_relax(relax.op.nn.sigmoid, data_numpy)
+    np.testing.assert_allclose(expected_output, result.numpy(), rtol=1e-6, atol=1e-6)
+
+def test_tanh():
+    data_numpy = np.random.randint(1, 16, (16, 16)).astype(np.float32)
+    expected_output = np.tanh(data_numpy)
+    result = run_relax(relax.op.nn.tanh, data_numpy)
     np.testing.assert_allclose(expected_output, result.numpy(), rtol=1e-6, atol=1e-6)
 
 if __name__ == "__main__":

--- a/tests/python/relax/training/test_numeric_gradient.py
+++ b/tests/python/relax/training/test_numeric_gradient.py
@@ -1,0 +1,122 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import numpy as np
+import pytest
+import tvm
+from tvm import relax
+from tvm.testing.utils import check_numerical_grads
+
+from utils import LowerToTensorIRPass
+import _gradient
+
+# add
+# sub
+# multiply
+# transpose
+# nn.relu
+# nn.matmul
+# nn.softmax_cross_entropy
+# nn.sigmoid
+# nn.tanh
+
+def relax_check_gradients(op, input_data, is_output_scalar = False):
+    """
+        generate module, transform it with SimpleADD and run it to check numberic gradients
+        ---
+        input: numpy array
+    """
+    # print(op, type(op))
+    func_name = "main"
+    data_type = relax.DynTensorType(dtype="float32")
+    input_list = []
+    tvm_data = []
+
+    for i in range(len(input_data)):
+        input_list.append(relax.Var("x_" + str(i), input_data[i].shape, data_type))
+        tvm_data.append(tvm.nd.array(input_data[i]))
+
+    bb = relax.BlockBuilder()
+    with bb.function(func_name, input_list):
+        with bb.dataflow():
+            if is_output_scalar:
+                out = bb.emit_output(op(*input_list))
+            else: 
+                lv0 = bb.emit(op(*input_list))
+                out = bb.emit_output(relax.op.sum(lv0))
+        bb.emit_func_output(out)
+    target = tvm.target.Target("llvm")
+    mod = bb.get()
+    mod.show()
+    lower_mod = LowerToTensorIRPass()(mod)
+    
+    def forward(*inputs):
+        ex_0 = relax.vm.build(lower_mod, target)
+        vm_0 = relax.VirtualMachine(ex_0, tvm.cpu())
+        result = vm_0["main"](*[tvm.nd.array(i) for i in inputs])
+        return result.numpy()
+
+    ad_mod = relax.transform.SimpleAD(mod.get_global_var("main"))(mod)
+    lower_ad_mod = LowerToTensorIRPass()(ad_mod)
+    ex = relax.vm.build(lower_ad_mod, target)
+    vm = relax.VirtualMachine(ex, tvm.cpu())
+    _, grads = vm["main_adjoint"](*tvm_data)
+
+    check_numerical_grads(forward, input_data, [i.numpy() for i in grads])
+
+
+def test_add():
+    data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    relax_check_gradients(relax.op.add, [data1_numpy, data2_numpy])
+
+def test_sub():
+    data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    relax_check_gradients(relax.op.sub, [data1_numpy, data2_numpy])
+
+def test_transpose():
+    data1_numpy = np.random.randint(0, 16, (5, 10)).astype(np.float32)
+    relax_check_gradients(relax.op.transpose, [data1_numpy])
+
+def test_relu():
+    data1_numpy = np.random.uniform(-1, 1, (16, 16)).astype(np.float32)
+    relax_check_gradients(relax.op.nn.relu, [data1_numpy])
+
+def test_matmul():
+    data1_numpy = np.random.randint(0, 16, (7, 8)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (8, 10)).astype(np.float32)
+    relax_check_gradients(relax.op.nn.matmul, [data1_numpy, data2_numpy])
+
+def test_softmax_cross_entropy():
+    data1_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
+    data2_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
+    data2_numpy /= np.sum(data2_numpy)
+    relax_check_gradients(relax.op.nn.softmax_cross_entropy, [data1_numpy, data2_numpy], True)
+
+def test_sigmoid():
+    data_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
+    relax_check_gradients(relax.op.nn.sigmoid, [data_numpy])
+
+def test_tanh():
+    data_numpy = np.random.randint(1, 16, (16, 16)).astype(np.float32)
+    relax_check_gradients(relax.op.nn.tanh, [data_numpy])
+
+if __name__ == "__main__":
+    pytest.main([__file__])
+    # test_softmax_cross_entropy()
+    # test_sigmoid()
+    # test_tanh()

--- a/tests/python/relax/training/utils.py
+++ b/tests/python/relax/training/utils.py
@@ -83,6 +83,12 @@ def map_softmax_cross_entropy(bb, call):
     func = lambda x, y: te_cross_entropy(topi.nn.softmax(x), y)
     return bb.call_te(func, call.args[0], call.args[1])
 
+def map_sigmoid(bb, call):
+    return bb.call_te(topi.sigmoid, call.args[0])
+
+def map_tanh(bb, call):
+    return bb.call_te(topi.tanh, call.args[0])
+
 def map_negative(bb, call):
     return bb.call_te(topi.negative, call.args[0])
 
@@ -125,6 +131,8 @@ op_map = {
   "relax.nn.softmax": map_softmax,
   "relax.nn.cross_entropy": map_cross_entropy,
   "relax.nn.softmax_cross_entropy": map_softmax_cross_entropy,
+  "relax.nn.sigmoid": map_sigmoid,
+  "relax.nn.tanh": map_tanh,
   "relax.negative": map_negative,
   "relax.ones_like": map_ones_like,
   "relax.zeros_like": map_zeros_like,
@@ -132,7 +140,7 @@ op_map = {
   "relax.log": map_log,
   "relax.sum": map_sum,
   "relax.zeros": map_zeros,
-  "relax.ones": map_ones,
+  "relax.ones": map_ones
 }
 
 @tvm.ir.transform.module_pass(opt_level=0, name="LowerToTensorIR")


### PR DESCRIPTION
This PR we try to implement a simple LSTM module in relax script. In detail, we add two new Ops `tanh` and `sigmoid` and do unit tests. Then using these Ops, we finish the backbone of LSTM and it successfully runs in a simple character classification task. Besides, a new test `test_numeric_gradient.py` is added to test whether every Op's gradient implementation is correct.